### PR TITLE
Update llama.js

### DIFF
--- a/src/service/llama/llama.js
+++ b/src/service/llama/llama.js
@@ -229,7 +229,7 @@ class LlamaCppService {
         if (process.platform === 'darwin') {
             // Ensure executable permissions
             try {
-                await fs.promises.chmod(binaryPath, '755');
+                await fs.chmod(binaryPath, '755');
                 logger.info('Set executable permissions for server binary');
             } catch (error) {
                 logger.error('Failed to set executable permissions:', error);


### PR DESCRIPTION
Fixed the code is incorrectly trying to access fs/promises through a non-existent promises property

## Description
Change this: `await fs.promises.chmod(binaryPath, '755');`
To this: `await fs.chmod(binaryPath, '755');`

This is a common mistake when transitioning between the older Node.js fs API (which uses fs.promises for Promise-based methods) and the newer direct fs/promises import (where the methods are directly available).

## Related Issues
None

## Type of Change
<!-- Check the relevant option(s) by putting an x in the brackets (no spaces) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing Performed
Couldn't test the fix as I don't have a mac

## Checklist
<!-- Check the relevant items by putting an x in the brackets (no spaces) -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] I have tested my changes in a packaged build
- [ ] Any dependent changes have been merged and published

## Additional Notes
None
